### PR TITLE
Fix gameserver not handling JoinRoom correctly

### DIFF
--- a/src/main/java/org/asf/centuria/packets/xt/gameserver/world/JoinRoom.java
+++ b/src/main/java/org/asf/centuria/packets/xt/gameserver/world/JoinRoom.java
@@ -52,12 +52,12 @@ public class JoinRoom implements IXtPacket<JoinRoom> {
 	@Override
 	public boolean handle(SmartfoxClient client) throws IOException {
 		Player plr = (Player) client.container;
+		roomIdentifier  = "room_" + levelID;
 		plr.teleportToRoom(levelID, levelType, issRoomID, roomIdentifier, teleport);
 		return true;
 	}
-	
-	public JoinRoom markAsFailed()
-	{
+
+	public JoinRoom markAsFailed() {
 		this.success = false;
 		this.roomIdentifier = "";
 		this.levelID = 0;

--- a/src/main/java/org/asf/centuria/packets/xt/gameserver/world/WorldReadyPacket.java
+++ b/src/main/java/org/asf/centuria/packets/xt/gameserver/world/WorldReadyPacket.java
@@ -142,14 +142,6 @@ public class WorldReadyPacket implements IXtPacket<WorldReadyPacket> {
 			if (!chClient.isInRoom("room_" + plr.levelID))
 				chClient.joinRoom("room_" + plr.levelID, false);
 
-			// Send response
-			JsonObject res = new JsonObject();
-			res.addProperty("conversationId", "room_" + plr.levelID);
-			res.addProperty("participant", plr.account.getAccountID());
-			res.addProperty("eventId", "conversations.addParticipant");
-			res.addProperty("success", true);
-			chClient.sendPacket(res);
-
 			// Make the player know its in the chat
 			plr.wasInChat = true;
 		}


### PR DESCRIPTION
The game server always sent room_0 for chat causing the client to use room_0 for all worlds, before i made the override on the game server to get chat to the right room, this caused all worlds to use the same room, however, after that last fix, no chat displayed as the client used room_0 and the server used the right one.

This fixes that