### PR TITLE
Fixed Bug Relating to Room Renaming

### DIFF
--- a/src/main/java/org/asf/centuria/packets/xt/gameserver/sanctuary/SanctuaryUpdatePacket.java
+++ b/src/main/java/org/asf/centuria/packets/xt/gameserver/sanctuary/SanctuaryUpdatePacket.java
@@ -167,9 +167,6 @@ public class SanctuaryUpdatePacket implements IXtPacket<SanctuaryUpdatePacket> {
 			var ilPacket = new InventoryItemPacket();
 			ilPacket.item = il;
 
-			writer = new XtWriter();
-			ilPacket.build(writer);
-
 			// send IL
 			plr.client.sendPacket(ilPacket);
 		}
@@ -179,17 +176,11 @@ public class SanctuaryUpdatePacket implements IXtPacket<SanctuaryUpdatePacket> {
 			var ilPacket = new InventoryItemPacket();
 			ilPacket.item = il;
 
-			writer = new XtWriter();
-			ilPacket.build(writer);
-
 			// send IL
 			plr.client.sendPacket(ilPacket);
 		}
 
 		// then do this packet
-
-		writer = new XtWriter();
-		this.build(writer);
 
 		plr.client.sendPacket(this);
 

--- a/src/main/java/org/asf/centuria/packets/xt/gameserver/sanctuary/SanctuaryUpdatePacket.java
+++ b/src/main/java/org/asf/centuria/packets/xt/gameserver/sanctuary/SanctuaryUpdatePacket.java
@@ -171,7 +171,7 @@ public class SanctuaryUpdatePacket implements IXtPacket<SanctuaryUpdatePacket> {
 			ilPacket.build(writer);
 
 			// send IL
-			plr.client.sendPacket(writer.encode());
+			plr.client.sendPacket(ilPacket);
 		}
 
 		if (roomChanges.size() > 0) {
@@ -183,7 +183,7 @@ public class SanctuaryUpdatePacket implements IXtPacket<SanctuaryUpdatePacket> {
 			ilPacket.build(writer);
 
 			// send IL
-			plr.client.sendPacket(writer.encode());
+			plr.client.sendPacket(ilPacket);
 		}
 
 		// then do this packet
@@ -191,7 +191,7 @@ public class SanctuaryUpdatePacket implements IXtPacket<SanctuaryUpdatePacket> {
 		writer = new XtWriter();
 		this.build(writer);
 
-		plr.client.sendPacket(writer.encode());
+		plr.client.sendPacket(this);
 
 		sendObjectUpdatePackets(client);
 


### PR DESCRIPTION
The headers for Inventory Item packets sent to the client were stripped of their headers, causing changes to room data (names and lighting) to not persist. This commit fixes this issue.